### PR TITLE
migrate from https to http

### DIFF
--- a/core/markup.php
+++ b/core/markup.php
@@ -118,7 +118,7 @@ if ( ! function_exists( 'cpotheme_logo' ) ) {
 				if ( is_ssl() ) {
 					$logo_url = preg_replace( '/^http:/i', 'https:', esc_url( cpotheme_get_option( 'general_logo' ) ) );
 				} else {
-					$logo_url = esc_url( cpotheme_get_option( 'general_logo' ) );
+					$logo_url = preg_replace( '/^https:/i', 'http:', esc_url( cpotheme_get_option( 'general_logo' ) ) );
 				}
 
 				if ( '' != $logo_width ) {


### PR DESCRIPTION
If you would like a site from https to http the general logo will have https url.
For example: i have a production site in https, but when i to change something important i have a local docker image where i put migrated site from https. The docker is http when i change hosts file and try load everything work less the general logo that is loaded it from https. This fix solve it.